### PR TITLE
Document NASA data API calls and externalize Earthdata token

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,14 @@ This project is built with:
 - shadcn-ui
 - Tailwind CSS
 
+## Data source API references
+
+The NASA data services used by CitySense Live Geo (GIBS WMTS tiles and SEDAC WMS/WCS layers) require specific API calls and, in some cases, authentication tokens. See [`docs/nasa-api-calls.md`](docs/nasa-api-calls.md) for copy-and-paste examples covering:
+
+- Retrieving NASA GIBS tiles for a given date.
+- Minting an Earthdata Login bearer token.
+- Downloading SEDAC map imagery.
+
 ## How can I deploy this project?
 
 Simply open [Lovable](https://lovable.dev/projects/00e61fe6-ebe2-4100-9f6e-21c4a5b56e05) and click on Share -> Publish.

--- a/docs/nasa-api-calls.md
+++ b/docs/nasa-api-calls.md
@@ -1,0 +1,54 @@
+# NASA Data Access Cheat Sheet
+
+This document lists the primary API calls required to fetch NASA datasets that power the CitySense Live Geo application. Copy and paste the snippets below into your terminal or client of choice and adjust the parameters (layer names, dates, bounding boxes) for your needs.
+
+## 1. NASA GIBS — WMTS (daily tiles, no auth required)
+
+Get a MODIS land surface temperature (LST) tile for a specific day using EPSG:4326 courtesy syntax:
+
+```
+https://gibs.earthdata.nasa.gov/wmts/epsg4326/best/MOD11A1_LST_Day_1km/default/2025-10-03/250m/8/xx/yy.png
+```
+
+For Leaflet, configure a WMTS tile layer like so:
+
+```ts
+L.tileLayer(
+  'https://gibs.earthdata.nasa.gov/wmts/epsg4326/best/{layer}/default/{time}/250m/{z}/{y}/{x}.png',
+  { layer: 'MOD11A1_LST_Day_1km', time: '2025-10-03', tileSize: 256, noWrap: true, attribution: 'NASA GIBS' }
+).addTo(map);
+```
+
+> Tip: Call `https://gibs.earthdata.nasa.gov/wmts/epsg4326/best/1.0.0/WMTSCapabilities.xml` to enumerate available layers and timestamps. For WMS requests append a `TIME` parameter.
+
+## 2. NASA Earthdata Login — obtain a user token
+
+Mint a user token (required for authenticated endpoints such as SEDAC downloads) by calling the Earthdata Login API with HTTP basic auth. Never store raw passwords in code—use environment variables or a secure secret store.
+
+```bash
+curl -u "$EDL_USERNAME:$EDL_PASSWORD" -X POST https://urs.earthdata.nasa.gov/api/users/tokens
+```
+
+Then call protected endpoints with the bearer token that is returned:
+
+```
+Authorization: Bearer <USER_TOKEN>
+```
+
+## 3. SEDAC — WMS map example (Population Exposure)
+
+```bash
+curl "https://sedac.ciesin.columbia.edu/geoserver/wms?service=WMS&version=1.3.0&request=GetMap&layers=gpw-v4:gpw-v4-population-density_2020&bbox=...&crs=EPSG:4326&width=1024&height=512&styles=&format=image/png"
+```
+
+`GetCapabilities` documents may move as SEDAC migrates infrastructure—always check the latest endpoint to confirm layer names.
+
+## 4. Application configuration
+
+Set the NASA Earthdata bearer token used by the frontend helpers in a Vite environment variable (e.g. `.env.local`):
+
+```
+VITE_NASA_EARTHDATA_TOKEN=YOUR_TOKEN_HERE
+```
+
+The `src/lib/sedac-api.ts` helpers will read this value or accept an override when you invoke them from other modules.

--- a/src/lib/sedac-api.ts
+++ b/src/lib/sedac-api.ts
@@ -4,9 +4,18 @@
 export const SEDAC_WMS_BASE = 'https://sedac.ciesin.columbia.edu/geoserver/wms';
 export const SEDAC_WCS_BASE = 'https://sedac.ciesin.columbia.edu/geoserver/wcs';
 
-// IMPORTANT: Store this token securely - consider using Lovable Cloud secrets for production
-// Token expires: May 2025 (exp: 1764756514)
-export const NASA_EARTHDATA_TOKEN = 'eyJ0eXAiOiJKV1QiLCJvcmlnaW4iOiJFYXJ0aGRhdGEgTG9naW4iLCJzaWciOiJlZGxqd3RwdWJrZXlfb3BzIiwiYWxnIjoiUlMyNTYifQ.eyJ0eXBlIjoiVXNlciIsInVpZCI6ImFjbXJzdSIsImV4cCI6MTc2NDc1NjUxNCwiaWF0IjoxNzU5NTcyNTE0LCJpc3MiOiJodHRwczovL3Vycy5lYXJ0aGRhdGEubmFzYS5nb3YiLCJpZGVudGl0eV9wcm92aWRlciI6ImVkbF9vcHMiLCJhY3IiOiJlZGwiLCJhc3N1cmFuY2VfbGV2ZWwiOjN9.hwZTEWTqF-iHEell4s8OYLlS7TjyBxMz_IoU7DtZ_E8KLFI3jpkquBMEo_b5OY8UqqkxIRYEDbfa_lJytjsORyd1tjSUI7GLdaE6FM6-_9XlJwVd8E_mYkxGhhFwYINRxGINVN01Oxh3MDmxxxYKpWkNfEogCTtR-EQSkKcnug5IMBu_YRtZgQjYRgPWNxfR_r0pEtPurcoSCOHx6i7pSGjkeO7x48rG0g2zuObxaMZ8ew6gQqQq8eFLU-z253uomSHS6MPaD6dsA95CTMftEHAxCWpLOGNEc9RtDrlWD-DzJmZ5NqOmhIFAVABdCJQGFAYFvChLn9edOgiy-UkewQ';
+function resolveEarthdataToken(tokenOverride?: string): string {
+  const envToken = import.meta.env?.VITE_NASA_EARTHDATA_TOKEN;
+  const token = tokenOverride ?? envToken;
+
+  if (!token) {
+    throw new Error(
+      'NASA Earthdata token is required. Set VITE_NASA_EARTHDATA_TOKEN in your environment or pass a token explicitly.'
+    );
+  }
+
+  return token;
+}
 
 export interface SEDACLayerConfig {
   workspace: string;
@@ -42,7 +51,8 @@ export async function fetchSEDACMap(
   bbox: [number, number, number, number], // [minLon, minLat, maxLon, maxLat]
   width: number = 1024,
   height: number = 512,
-  crs: string = 'EPSG:4326'
+  crs: string = 'EPSG:4326',
+  authToken?: string
 ): Promise<Blob> {
   const layerConfig = SEDAC_LAYERS[layerKey];
   if (!layerConfig) {
@@ -65,9 +75,11 @@ export async function fetchSEDACMap(
 
   const url = `${SEDAC_WMS_BASE}?${params.toString()}`;
 
+  const token = resolveEarthdataToken(authToken);
+
   const response = await fetch(url, {
     headers: {
-      'Authorization': `Bearer ${NASA_EARTHDATA_TOKEN}`
+      'Authorization': `Bearer ${token}`
     }
   });
 
@@ -93,12 +105,14 @@ export function getSEDACWMSUrl(layerKey: string): string {
 /**
  * Fetch SEDAC capabilities
  */
-export async function fetchSEDACCapabilities(): Promise<string> {
+export async function fetchSEDACCapabilities(authToken?: string): Promise<string> {
   const url = `${SEDAC_WMS_BASE}?service=WMS&version=1.3.0&request=GetCapabilities`;
-  
+
+  const token = resolveEarthdataToken(authToken);
+
   const response = await fetch(url, {
     headers: {
-      'Authorization': `Bearer ${NASA_EARTHDATA_TOKEN}`
+      'Authorization': `Bearer ${token}`
     }
   });
 
@@ -115,7 +129,8 @@ export async function fetchSEDACCapabilities(): Promise<string> {
 export async function downloadSEDACRaster(
   layerKey: string,
   bbox: [number, number, number, number],
-  format: string = 'GeoTIFF'
+  format: string = 'GeoTIFF',
+  authToken?: string
 ): Promise<Blob> {
   const layerConfig = SEDAC_LAYERS[layerKey];
   if (!layerConfig) {
@@ -134,9 +149,11 @@ export async function downloadSEDACRaster(
 
   const url = `${SEDAC_WCS_BASE}?${params.toString()}`;
 
+  const token = resolveEarthdataToken(authToken);
+
   const response = await fetch(url, {
     headers: {
-      'Authorization': `Bearer ${NASA_EARTHDATA_TOKEN}`
+      'Authorization': `Bearer ${token}`
     }
   });
 

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,1 +1,9 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_NASA_EARTHDATA_TOKEN?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
## Summary
- add a NASA data access cheat sheet with ready-to-use API call examples
- link the new documentation from the README for quick discovery
- remove the hard-coded Earthdata token and allow supplying it via environment variables or overrides
- declare the expected Vite environment variable for type safety

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e0f95cba8c83218befdbb90ddc4757